### PR TITLE
 Creación de docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,14 +32,32 @@ En la wiki_ desarrollamos documentación (tanto técnica como no técnica).
 .. _wiki: https://github.com/democraciaconcodigos/escrutiniosocial/wiki
 
 
-Entorno de desarrollo
+Entorno de desarrollo con Docker
+---------------------
+
+Este es un proyecto basado en Django y cuenta con la configuracion de docker para levantar los servicios en contenedores.
+
+Para levantar el proyecto necesitamos contar con docker (https://docs.docker.com/engine/installation/) y docker-compose (https://docs.docker.com/compose/install/).
+
+  `Se recomienda seguir los pasos post instalación para poder ejecutar docker sin utilizar el usuario root.`
+
+Una vez instaladas las dependencias debemos entrar en la carpeta de docker y ejecutar `docker-compose up`.
+
+.. code:: bash
+
+  cd docker
+  docker-compose up
+
+Luego de finalizado el proceso podrán acceder a través de `http://localhost:8000/`.
+
+Un superusuario ``admin`` con clave ``admin`` se habrá cargado
+
+Entorno de desarrollo - Instalación tradicional
 ---------------------
 
 Es un proyecto basado en Django. Requiere Python 3.6 y Postgresql.
-
-
 Podés ver este `tutorial <https://tutorial.djangogirls.org/es/django_installation/>`_
-para instrucciones detalladas.
+para instrucciones detalladas de como instalar Django con python 3.6.
 
 1. Crear un virtualenv
 2. ``pip install -r requirements.txt``
@@ -50,14 +68,3 @@ para instrucciones detalladas.
 6. ``python manage.py runserver``
 
 Un superusuario ``admin`` con clave ``admin`` se habrá cargado
-
-
-
-
-
-
-
-
-
-
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_DB=escrutiniociudadano
+      - POSTGRES_USER=escrutinio
+      - POSTGRES_PASSWORD=development
+  web:
+    build: ./python-docker
+    volumes:
+      - ../:/project
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db

--- a/docker/python-docker/Dockerfile
+++ b/docker/python-docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+RUN apt-get update
+RUN apt-get install -y python3-gdal
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /project
+WORKDIR /project
+ADD local-settings-docker.py /tmp/
+COPY ./entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/python-docker/entrypoint.sh
+++ b/docker/python-docker/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ ! -f /project/escrutiniociudadano/local_settings.py ]; then
+  cat /tmp/local-settings-docker.py >> /project/escrutiniociudadano/local_settings.py
+else
+  if ! cat /project/escrutiniociudadano/local_settings.py | grep "DATABASES"; then
+    echo "DATABASES = {" >> /project/escrutiniociudadano/local_settings.py
+    echo "    'default': {" >> /project/escrutiniociudadano/local_settings.py
+    echo "        'ENGINE': 'django.db.backends.postgresql'," >> /project/escrutiniociudadano/local_settings.py
+    echo "        'NAME': 'escrutiniociudadano'," >> /project/escrutiniociudadano/local_settings.py
+    echo "        'USER': 'escrutinio'," >> /project/escrutiniociudadano/local_settings.py
+    echo "        'PASSWORD': 'development'," >> /project/escrutiniociudadano/local_settings.py
+    echo "        'HOST': 'db'," >> /project/escrutiniociudadano/local_settings.py
+    echo "        'PORT': '5432'," >> /project/escrutiniociudadano/local_settings.py
+    echo "    }" >> /project/escrutiniociudadano/local_settings.py
+    echo "}" >> /project/escrutiniociudadano/local_settings.py
+  fi
+  if ! cat /project/escrutiniociudadano/local_settings.py | grep "GOOGLE_ANALYTICS_PROPERTY_ID"; then
+    echo "GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-345678-2'" >> /project/escrutiniociudadano/local_settings.py
+  fi
+fi
+
+echo "Installing required packages" \
+ && pip3 install -r /project/requirements.txt \
+ && echo "Packages installation finished" \
+ && python3.6 /project/manage.py migrate \
+ && python3.6 /project/manage.py loaddata fixtures/* \
+ && python3.6 /project/manage.py runserver 0.0.0.0:8000 \

--- a/docker/python-docker/local-settings-docker.py
+++ b/docker/python-docker/local-settings-docker.py
@@ -1,0 +1,13 @@
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'escrutiniociudadano',
+        'USER': 'escrutinio',
+        'PASSWORD': 'development',
+        'HOST': 'db',
+        'PORT': '5432',
+    }
+}
+
+GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-XXXXXX-Y'


### PR DESCRIPTION
El docker vincula el directorio del proyecto del contenedor con el proyecto fuera de el.
Para correr estos servicios debemos pararnos dentro del directorio "docker" y correr `docker-compose up`.
Falta agregar:
- Crear script con alguna ayuda para correr comandos dentro del docker
- Mover los comandos de manage que deban correr 1 sola vez o agregar condicion
